### PR TITLE
Switch text-decoration property to camel-case

### DIFF
--- a/web/src/components/todo-list-item.js
+++ b/web/src/components/todo-list-item.js
@@ -14,7 +14,7 @@ export default class TodoListItem extends React.Component {
         const {task, isCompleted} = this.props;
         const taskStyle = {
             color: isCompleted? 'green' : 'red',
-            'text-decoration': isCompleted? 'line-through' : '',
+            'textDecoration': isCompleted? 'line-through' : '',
             cursor: 'pointer'
         };
         if(this.state.isEditing){


### PR DESCRIPTION
"Unsupported style property text-decoration. Did you mean textDecoration? Check the render method of `TodoListItem`"

![screenshot 2016-10-09 19 03 51](https://cloud.githubusercontent.com/assets/4411839/19225552/7affd5ae-8e53-11e6-9c26-a07ba985ebde.png)
