### PR TITLE
Fix request template which was breaking json body parsing

### DIFF
--- a/serverless/templates.yml
+++ b/serverless/templates.yml
@@ -2,7 +2,7 @@ request:
   template:
     application/json: >
       {
-        "data": "$input.json('$')",
+        "data": $input.json('$'),
         "path": "$context.resourcePath",
         "stage": "$context.stage",
         "method": "$context.httpMethod",


### PR DESCRIPTION
According to http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-mapping-template-reference.html#input-example-json-mapping-template there should be no surrounding double quotes
