### PR TITLE
Add Unit Testing Framework Fixes #19

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,10 @@
     "preinstall": "cd web && npm install",
     "postinstall": "cd serverless && npm install",
     "db-setup": "cd serverless && sls dynamodb install",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "mocha --compilers js:babel-register --require ./test/helpers.js --require ./test/dom.js --recursive",
+    "tdd": "npm test -- --watch",
+    "dev": "webpack-dev-server --port 3000 --devtool eval --progress --colors --hot --content-base dist",
+    "build": "webpack -p"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,11 @@
   },
   "homepage": "https://github.com/mjzone/serverless-boilerplate#readme",
   "devDependencies": {
-    "opn": "4.0.2"
+    "chai": "^4.1.1",
+    "enzyme": "^2.9.1",
+    "mocha": "^3.5.0",
+    "opn": "4.0.2",
+    "react-addons-test-utils": "^15.6.0",
+    "sinon": "^3.2.1"
   }
 }

--- a/test/dom.js
+++ b/test/dom.js
@@ -1,0 +1,16 @@
+/* dom.js */
+var jsdom = require('jsdom').jsdom;
+var exposedProperties = ['window', 'navigator', 'document'];
+
+global.document = jsdom('');
+global.window = document.defaultView;
+Object.keys(document.defaultView).forEach((property) => {
+  if (typeof global[property] === 'undefined') {
+    exposedProperties.push(property);
+    global[property] = document.defaultView[property];
+  }
+});
+
+global.navigator = {
+  userAgent: 'node.js'
+};

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,0 +1,14 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import { expect } from 'chai';
+import { sinon, spy } from 'sinon';
+import { mount, render, shallow } from 'enzyme';
+
+global.expect = expect;
+global.sinon = sinon;
+global.spy = spy;
+
+global.mount = mount;
+global.render = render;
+global.shallow = shallow;


### PR DESCRIPTION
Added the Mocha unit testing framework. This Fixes #19 .

- Added the testing dependencies for Mocha, Chai, Sinon and Enzyme.
- Did the setting up for testing framework in package.json.
- Added helper files to test folder.

Request for review: @mjzone , @lakindu95 
